### PR TITLE
Implemented function that return number of followers

### DIFF
--- a/data/followers.js
+++ b/data/followers.js
@@ -35,6 +35,24 @@ const createFollowers = async (userId, followedUserId) => {
     return {followerAdded: false};
 };
 
+
+const getAllFollowers = async (userId) => {
+    // validation
+    validationFunctions.idValidator(userId);
+
+    userId = userId.trim();
+
+    let followersCollection = await followers();
+
+    // As the followers data is created when current logged in user, start following some other user.
+    // So, to get the count of people following the current logged in user, 
+    // we have to get the record of the people in whoes followed_user_id is equal to current user's id.
+    let followersCount = await followersCollection.find({followed_user_id: userId}).count();
+
+    return followersCount;
+};
+
 module.exports = {
-    createFollowers
+    createFollowers,
+    getAllFollowers
 };


### PR DESCRIPTION
As the followers data is created when current logged in user, start following some other user. So, to get the count of people following the current logged in user, we have to get the record of the people in whose followed_user_id is equal to current user's id.